### PR TITLE
Reward & Quest Tables, Meret Market Fix (again)

### DIFF
--- a/Maple2.File.Parser/Enum/ChapterBookRewardType.cs
+++ b/Maple2.File.Parser/Enum/ChapterBookRewardType.cs
@@ -1,0 +1,7 @@
+﻿namespace Maple2.File.Parser.Enum;
+
+public enum ChapterBookRewardType {
+    unknown = 0,
+    item = 1,
+    skillPoint = 2,
+}

--- a/Maple2.File.Parser/Maple2.File.Parser.csproj
+++ b/Maple2.File.Parser/Maple2.File.Parser.csproj
@@ -11,7 +11,7 @@
         <PackageTags>MapleStory2, File, Parser, m2d, xml</PackageTags>
         <!-- Use following lines to write the generated files to disk. -->
         <EmitCompilerGeneratedFiles Condition=" '$(Configuration)' == 'Debug' ">true</EmitCompilerGeneratedFiles>
-        <PackageVersion>2.0.22</PackageVersion>
+        <PackageVersion>2.0.23</PackageVersion>
         <TargetFramework>net7.0</TargetFramework>
     </PropertyGroup>
 

--- a/Maple2.File.Parser/Xml/Table/ChapterBook.cs
+++ b/Maple2.File.Parser/Xml/Table/ChapterBook.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.Serialization;
+using M2dXmlGenerator;
+using Maple2.File.Parser.Enum;
+
+namespace Maple2.File.Parser.Xml.Table;
+
+// ./data/xml/table/na/chapterbook.xml
+[XmlRoot("ms2")]
+public partial class ChapterBookRoot {
+    [M2dFeatureLocale(Selector = "id")] private IList<ChapterBook> _chapterbook;
+}
+
+public partial class ChapterBook : IFeatureLocale {
+    [XmlAttribute] public int id;
+    [XmlAttribute] public int prologue;
+    [XmlAttribute] public int epilogue;
+    [XmlAttribute] public ChapterBookRewardType rewardType1;
+    [M2dArray] public string[] rewardValue1 = Array.Empty<string>();
+    [XmlAttribute] public ChapterBookRewardType rewardType2;
+    [M2dArray] public string[] rewardValue2 = Array.Empty<string>();
+}

--- a/Maple2.File.Parser/Xml/Table/LearningQuest.cs
+++ b/Maple2.File.Parser/Xml/Table/LearningQuest.cs
@@ -16,7 +16,7 @@ public partial class LearningQuest : IFeatureLocale {
     [XmlAttribute] public int reqLevel;
     [XmlAttribute] public int reqQuest;
     [XmlAttribute] public int reqField;
-    [XmlAttribute] public string movie;
+    [XmlAttribute] public string movie = string.Empty;
     [XmlAttribute] public int gotoField;
     [XmlAttribute] public int gotoPortal;
 }

--- a/Maple2.File.Parser/Xml/Table/LearningQuest.cs
+++ b/Maple2.File.Parser/Xml/Table/LearningQuest.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Xml.Serialization;
+using M2dXmlGenerator;
+
+namespace Maple2.File.Parser.Xml.Table;
+
+// ./data/xml/table/learningquest.xml
+[XmlRoot("ms2")]
+public partial class LearningQuestRoot {
+    [M2dFeatureLocale(Selector = "id")] private IList<LearningQuest> _learning;
+}
+
+public partial class LearningQuest : IFeatureLocale {
+    [XmlAttribute] public int id;
+    [XmlAttribute] public int category;
+    [XmlAttribute] public int reqLevel;
+    [XmlAttribute] public int reqQuest;
+    [XmlAttribute] public int reqField;
+    [XmlAttribute] public string movie;
+    [XmlAttribute] public int gotoField;
+    [XmlAttribute] public int gotoPortal;
+}

--- a/Maple2.File.Parser/Xml/Table/MasteryDifferentialFactor.cs
+++ b/Maple2.File.Parser/Xml/Table/MasteryDifferentialFactor.cs
@@ -15,5 +15,5 @@ public class MasteryDifferentialFactorRoot {
 public class MasteryDifferentialFactor {
     [XmlAttribute] public int differential;
     [XmlAttribute] public int factor;
-    [XmlAttribute] public string icon;
+    [XmlAttribute] public string icon = string.Empty;
 }

--- a/Maple2.File.Parser/Xml/Table/MasteryDifferentialFactor.cs
+++ b/Maple2.File.Parser/Xml/Table/MasteryDifferentialFactor.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.Serialization;
+using M2dXmlGenerator;
+using Maple2.File.Parser.Enum;
+
+namespace Maple2.File.Parser.Xml.Table;
+
+// ./data/xml/table/masterydifferentialfactor.xml
+[XmlRoot("ms2")]
+public class MasteryDifferentialFactorRoot {
+    [XmlElement] public List<MasteryDifferentialFactor> v;
+}
+
+public class MasteryDifferentialFactor {
+    [XmlAttribute] public int differential;
+    [XmlAttribute] public int factor;
+    [XmlAttribute] public string icon;
+}

--- a/Maple2.File.Parser/Xml/Table/RewardContent.cs
+++ b/Maple2.File.Parser/Xml/Table/RewardContent.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.Xml.Serialization;
+using M2dXmlGenerator;
+
+namespace Maple2.File.Parser.Xml.Table;
+
+// ./data/xml/table/rewardcontent.xml
+[XmlRoot("ms2")]
+public partial class RewardContentRoot {
+    [M2dFeatureLocale(Selector = "rewardID")] private IList<RewardContent> _v;
+}
+
+public partial class RewardContent : IFeatureLocale {
+    [XmlAttribute] public int rewardID;
+    [XmlAttribute] public int mesoTableID;
+    [XmlAttribute] public float mesoFactor;
+    [XmlAttribute] public int expTableID;
+    [XmlAttribute] public float expFactor;
+    [XmlAttribute] public int itemTableID;
+    [XmlAttribute] public int adventureExpTableID;
+}

--- a/Maple2.File.Parser/Xml/Table/RewardContentExpStatic.cs
+++ b/Maple2.File.Parser/Xml/Table/RewardContentExpStatic.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace Maple2.File.Parser.Xml.Table;
+
+// ./data/xml/table/rewardcontentexpstatictable.xml
+[XmlRoot("ms2")]
+public class RewardContentExpStaticRoot {
+    [XmlElement] public List<RewardContentExpStatic> table;
+}
+
+public class RewardContentExpStatic { 
+    [XmlAttribute] public int expTableID;
+    [XmlElement] public List<RewardContentExpBase> @base;
+}
+
+public class RewardContentExpBase {
+    [XmlAttribute] public long exp;
+}

--- a/Maple2.File.Parser/Xml/Table/RewardContentItem.cs
+++ b/Maple2.File.Parser/Xml/Table/RewardContentItem.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace Maple2.File.Parser.Xml.Table;
+
+// ./data/xml/table/rewardcontentitemtable.xml
+[XmlRoot("ms2")]
+public class RewardContentItemRoot {
+    [XmlElement] public List<RewardContentItem> table;
+}
+
+public class RewardContentItem { 
+    [XmlAttribute] public int itemTableID;
+    [XmlElement] public List<RewardContentValue> v;
+}
+
+public class RewardContentValue {
+    [XmlAttribute] public int minLevel;
+    [XmlAttribute] public int maxLevel;
+    
+    [XmlElement] public List<RewardContentItemEntry> item;
+}
+
+public class RewardContentItemEntry {
+    [XmlAttribute] public int itemID;
+    [XmlAttribute] public int count;
+    [XmlAttribute] public int grade;
+}

--- a/Maple2.File.Parser/Xml/Table/RewardContentMeso.cs
+++ b/Maple2.File.Parser/Xml/Table/RewardContentMeso.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace Maple2.File.Parser.Xml.Table;
+
+// ./data/xml/table/rewardcontentmesotable.xml
+[XmlRoot("ms2")]
+public class RewardContentMesoRoot {
+    [XmlElement] public List<RewardContentMeso> table;
+}
+
+public class RewardContentMeso { 
+    [XmlAttribute] public int mesoTableID;
+    [XmlElement] public List<RewardContentMesoValue> v;
+}
+
+public class RewardContentMesoValue {
+    [XmlAttribute] public int level;
+    [XmlAttribute] public long meso;
+}

--- a/Maple2.File.Parser/Xml/Table/RewardContentMesoStatic.cs
+++ b/Maple2.File.Parser/Xml/Table/RewardContentMesoStatic.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace Maple2.File.Parser.Xml.Table;
+
+// ./data/xml/table/rewardcontentmesostatictable.xml
+[XmlRoot("ms2")]
+public class RewardContentMesoStaticRoot {
+    [XmlElement] public List<RewardContentMesoStatic> table;
+}
+
+public class RewardContentMesoStatic { 
+    [XmlAttribute] public int mesoTableID;
+    [XmlElement] public List<RewardContentMesoStaticValue> v;
+}
+
+public class RewardContentMesoStaticValue {
+    [XmlAttribute] public long meso;
+}

--- a/Maple2.File.Tests/TableParserTest.cs
+++ b/Maple2.File.Tests/TableParserTest.cs
@@ -551,4 +551,76 @@ public class TableParserTest {
             continue;
         }
     }
+
+    [TestMethod]
+    public void TestChapterBook() {
+        var parser = new TableParser(TestUtils.XmlReader);
+
+        foreach ((_, _) in parser.ParseChapterBook()) {
+            continue;
+        }
+    }
+
+    [TestMethod]
+    public void TestLearningQuest() {
+        var parser = new TableParser(TestUtils.XmlReader);
+
+        foreach ((_, _) in parser.ParseLearningQuest()) {
+            continue;
+        }
+    }
+
+    [TestMethod]
+    public void TestMasteryDifferentialFactor() {
+        var parser = new TableParser(TestUtils.XmlReader);
+
+        foreach ((_, _) in parser.ParseMasteryDifferentialFactor()) {
+            continue;
+        }
+    }
+
+    [TestMethod]
+    public void TestRewardContent() {
+        var parser = new TableParser(TestUtils.XmlReader);
+
+        foreach ((_, _) in parser.ParseRewardContent()) {
+            continue;
+        }
+    }
+
+    [TestMethod]
+    public void TestRewardContentItem() {
+        var parser = new TableParser(TestUtils.XmlReader);
+
+        foreach ((_, _) in parser.ParseRewardContentItem()) {
+            continue;
+        }
+    }
+
+    [TestMethod]
+    public void TestRewardContentExpStatic() {
+        var parser = new TableParser(TestUtils.XmlReader);
+
+        foreach ((_, _) in parser.ParseRewardContentExpStatic()) {
+            continue;
+        }
+    }
+
+    [TestMethod]
+    public void TestRewardContentMeso() {
+        var parser = new TableParser(TestUtils.XmlReader);
+
+        foreach ((_, _) in parser.ParseRewardContentMeso()) {
+            continue;
+        }
+    }
+
+    [TestMethod]
+    public void TestRewardContentMesoStatic() {
+        var parser = new TableParser(TestUtils.XmlReader);
+
+        foreach ((_, _) in parser.ParseRewardContentMesoStatic()) {
+            continue;
+        }
+    }
 }


### PR DESCRIPTION
- Had to change Meret Market yet again. Previous implementation just complete wipes out the UGC Market. This should now only override if there's existing values in `environment`.
- Parsing a few more tables. I'm noticing that the MesoStatic and ExpStatic tables look very similar to their counterparts of Meso and Exp tables. I didn't decide to merge them together because it's technically missing the level attribute. Let me know if I should merge it so it uses the same serializer.